### PR TITLE
Add shebang to flycheck shell script

### DIFF
--- a/bin/kibit-flymake.sh
+++ b/bin/kibit-flymake.sh
@@ -1,3 +1,4 @@
+#! /bin/sh
 # Setting basedir on flymake tasks doesn't actually get set beyond a
 # logging statement, so we hijack the CWD using this script to farm
 # out the job to leiningen


### PR DESCRIPTION
Flycheck fails to execute `kibit-flymake.sh` on some systems without an explicit shebang.
