### PR TITLE
Migrate to new flycheck checker definition macro.

### DIFF
--- a/kibit-mode.el
+++ b/kibit-mode.el
@@ -113,11 +113,11 @@ Emacs Lisp package."))
 
 (eval-after-load 'flycheck
   '(progn
-     (flycheck-declare-checker clojure-kibit
+     (flycheck-define-checker clojure-kibit
        "A Clojure code analyzer using the kibit utility."
-       :command `(,(concat kibit-mode-path "bin/kibit-flymake.sh") source)
-       :error-patterns '(("\\(?1:.*\\):\\(?2:[0-9]+\\): \\(?4:ERROR: .* CORRECTION: .*\\)" error))
-       :modes 'clojure-mode)
+       :command ((eval (concat kibit-mode-path "bin/kibit-flymake.sh")) source)
+       :error-patterns ((error line-start (file-name) ":" line ": " (message) line-end ))
+       :modes clojure-mode)
      (add-to-list 'flycheck-checkers 'clojure-kibit)))
 
 (provide 'kibit-mode)

--- a/kibit-mode.el
+++ b/kibit-mode.el
@@ -113,11 +113,22 @@ Emacs Lisp package."))
 
 (eval-after-load 'flycheck
   '(progn
-     (flycheck-define-checker clojure-kibit
-       "A Clojure code analyzer using the kibit utility."
-       :command ((eval (concat kibit-mode-path "bin/kibit-flymake.sh")) source)
-       :error-patterns ((error line-start (file-name) ":" line ": " (message) line-end ))
-       :modes clojure-mode)
+     (cond
+      ;; New macro definition
+      ((fboundp 'flycheck-define-checker)
+       (flycheck-define-checker clojure-kibit
+         "A Clojure code analyzer using the kibit utility."
+         :command ((eval (concat kibit-mode-path "bin/kibit-flymake.sh")) source)
+         :error-patterns ((error line-start (file-name) ":" line ": ERROR: " (message) line-end ))
+         :modes clojure-mode))
+      ;; Backwards compatibility
+      ((fboundp 'flycheck-declare-checker)
+       (flycheck-declare-checker
+        clojure-kibit
+        "A Clojure code analyzer using the kibit utility."
+        :command `(,(concat kibit-mode-path "bin/kibit-flymake.sh") source)
+        :error-patterns '(("\\(?1:.*\\):\\(?2:[0-9]+\\): \\(?4:ERROR: .* CORRECTION: .*\\)" error))
+        :modes 'clojure-mode)))
      (add-to-list 'flycheck-checkers 'clojure-kibit)))
 
 (provide 'kibit-mode)


### PR DESCRIPTION
A recent commit to flycheck removed the checker definition macro kibit
is currently using, effectively breaking compatibility.

Please refer to: https://github.com/flycheck/flycheck/commit/5aef21f515fb5166df35304da3871cab7ea4af46

These changes support the new checker's definition syntax, ~~without
trying to maintain backwards compatibility~~.
