### PR TITLE
Bump to kibit 0.0.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@
 /.lein-failures
 /checkouts
 /.lein-deps-sum
-/target/stale/dependencies
+/target

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ idiomatic.
 ## Requirements
 
 * [Emacs](http://www.gnu.org/software/emacs/) 24.0 or greater
-* [Clojure](http://clojure.org) 1.4 or greater
+* [Clojure](http://clojure.org) 1.6 or greater
 * [Leiningen](https://github.com/technomancy/leiningen) 1.6.2 or greater
 * [clojure-mode](https://github.com/technomancy/clojure-mode) 1.11.5 or greater
 

--- a/project.clj
+++ b/project.clj
@@ -1,9 +1,8 @@
 (defproject kibit-mode "0.0.1"
   :description "A kibit compiler for Clojure files"
-  :dependencies [[org.clojure/clojure "1.4.0"]
-                 [jonase/kibit "0.0.3"]]
+  :dependencies [[org.clojure/clojure "1.6.0"]
+                 [jonase/kibit "0.0.8"]]
   :profiles {:dev {:resource-paths ["bogus_src"]
-                   :dependencies [[midje "1.4.0"]
-                                  [lein-midje "2.0.0-SNAPSHOT"]]}}
-  :eval-in :leiningen
-  )
+                   :dependencies [[midje "1.6.3"]
+                                  [lein-midje "3.1.3"]]}}
+  :eval-in :leiningen)


### PR DESCRIPTION
This Pull request bumps kibit to 0.0.8 and clojure to 1.6.0

There have been some additions that would be super useful for those
using kibit-mode to define a flycheck checker for their Clojure.

Also, honorable mention to current versions of Midje and lein-midje
