### PR TITLE
exec-path-from-shell resets exec-path

### DIFF
--- a/kibit-mode.el
+++ b/kibit-mode.el
@@ -133,5 +133,9 @@ Emacs Lisp package."))
         :modes 'clojure-mode)))
      (add-to-list 'flycheck-checkers 'clojure-kibit)))
 
+(eval-after-load 'exec-path-from-shell
+  '(defadvice exec-path-from-shell-initialize (after reset-kibit-path activate)
+     (add-to-list 'exec-path (concat kibit-mode-path "bin"))))
+
 (provide 'kibit-mode)
 ;;; kibit-mode.el ends here


### PR DESCRIPTION
This ensures that kibit-mode-path is added back to exec-path once
exec-path-from-shell-initialize is run. I have this in my init.d config
and it could be useful for others too.

If exec-path-from-shell isn't installed, this should do nothing.
