### PR TITLE
Fix malformatted dependency declaration

### DIFF
--- a/kibit-mode.el
+++ b/kibit-mode.el
@@ -6,8 +6,7 @@
 ;; Created: 2012
 ;; Version: 0.1
 ;; Keywords: clojure kibit
-;; Package-Requires: ((clojure-mode "1.11.5")
-;;                    (mode-compile "2.29"))
+;; Package-Requires: ((clojure-mode "1.11.5") (mode-compile "2.29"))
 
 ;;; Commentary:
 ;;


### PR DESCRIPTION
The newline prevented `package-buffer-info` from parsing the file, leading to missing dependencies and description on MELPA.
